### PR TITLE
Release 0.2.1: fix collectstatic under manifest storage

### DIFF
--- a/django_cotton_ui/static/django_cotton_ui/cotton-ui.tokens.css
+++ b/django_cotton_ui/static/django_cotton_ui/cotton-ui.tokens.css
@@ -1,23 +1,5 @@
-/*
- * Cotton UI styles — the kit's single stylesheet.
- *
- * Import once into your Tailwind v4 entry, AFTER `@import "tailwindcss"`:
- *
- *     @import "tailwindcss";
- *     @import "<path>/static/cotton-ui/cotton-ui.css";
- *     @source "<path>/templates";
- *
- * One import compiles everything the components need into your CSS: the accent
- * palette (neutral zinc by default), the component tokens (radius, surfaces,
- * shadows, focus ring) and the Alpine `x-cloak` rule.
- *
- * Note: `@import` this into your Tailwind entry (it contains `@theme`); do NOT
- * `<link>` it at runtime. To brand the kit, override --color-accent in your own
- * @theme AFTER this import:
- *
- *     @theme { --color-accent: var(--color-teal-500); --color-accent-content: var(--color-teal-600); }
- *     @layer theme { .dark { --color-accent: var(--color-teal-400); --color-accent-content: var(--color-teal-300); } }
- */
+/* Cotton UI tokens: accent palette, component tokens (radius, surfaces, shadows,
+   focus ring) and x-cloak. Brand by overriding --color-accent via :root / .dark. */
 
 @theme {
     --color-accent: var(--color-zinc-900);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,12 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "django-cotton-ui"
-version = "0.2.0"
+version = "0.2.1"
 description = "UI component library for Django Cotton"
 authors = ["Will Abbott <willabb83@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 packages = [{include = "django_cotton_ui"}]
-exclude = ["django_cotton_ui/static/django_cotton_ui/*.map"]
 homepage = "https://github.com/wrabit/django-cotton-ui"
 repository = "https://github.com/wrabit/django-cotton-ui"
 keywords = ["django", "components", "ui", "tailwind", "alpine"]

--- a/src/css/cotton-ui.css
+++ b/src/css/cotton-ui.css
@@ -1,23 +1,5 @@
-/*
- * Cotton UI styles — the kit's single stylesheet.
- *
- * Import once into your Tailwind v4 entry, AFTER `@import "tailwindcss"`:
- *
- *     @import "tailwindcss";
- *     @import "<path>/static/cotton-ui/cotton-ui.css";
- *     @source "<path>/templates";
- *
- * One import compiles everything the components need into your CSS: the accent
- * palette (neutral zinc by default), the component tokens (radius, surfaces,
- * shadows, focus ring) and the Alpine `x-cloak` rule.
- *
- * Note: `@import` this into your Tailwind entry (it contains `@theme`); do NOT
- * `<link>` it at runtime. To brand the kit, override --color-accent in your own
- * @theme AFTER this import:
- *
- *     @theme { --color-accent: var(--color-teal-500); --color-accent-content: var(--color-teal-600); }
- *     @layer theme { .dark { --color-accent: var(--color-teal-400); --color-accent-content: var(--color-teal-300); } }
- */
+/* Cotton UI tokens: accent palette, component tokens (radius, surfaces, shadows,
+   focus ring) and x-cloak. Brand by overriding --color-accent via :root / .dark. */
 
 @theme {
     --color-accent: var(--color-zinc-900);


### PR DESCRIPTION
0.2.0 (and 0.1.0) fail collectstatic for consumers using a manifest static files storage. This fixes both causes.

- Strip the @import examples from the cotton-ui.tokens.css header comment. Django/whitenoise ManifestStaticFilesStorage scans CSS for @import and url references and tried to resolve them as static files, raising MissingFileError.
- Ship cotton-ui.min.js.map again. A stale exclude rule dropped it, leaving a dangling sourceMappingURL in cotton-ui.min.js that the same storage could not resolve.

Validated by installing the wheel into a clean venv and running collectstatic under CompressedManifestStaticFilesStorage: passes on all kit static, no dangling references.