### PR TITLE
Release 0.2.2: fix Alpine x-data (interactive components broken)

### DIFF
--- a/django_cotton_ui/templates/cotton/ui/combobox/impl.html
+++ b/django_cotton_ui/templates/cotton/ui/combobox/impl.html
@@ -33,8 +33,8 @@
         disabled: {{ disabled|lower }}
      })"
      x-init="
-        initSelected('{{ selected|json_dumps }}');
-        initOptions('{{ options|json_dumps }}');
+        initSelected('{{ selected|json_dumps_uri }}');
+        initOptions('{{ options|json_dumps_uri }}');
      "
      class="relative w-full group"
      {{ attrs }}

--- a/django_cotton_ui/templatetags/cotton_ui.py
+++ b/django_cotton_ui/templatetags/cotton_ui.py
@@ -10,15 +10,16 @@ register = template.Library()
 
 @register.filter
 def json_dumps(value):
-    """
-    Serialize value to JSON and URL-encode for safe embedding in HTML attributes.
+    """JSON-serialize for a bare JS literal in an x-data expression, e.g.
+    x-data='radio("{{ name }}", {{ value|json_dumps }})'. Django auto-escapes the
+    quotes and the browser decodes them, so the literal stays valid (and safe)."""
+    return json.dumps(value)
 
-    Used by components like combobox that need to pass Python data structures
-    to Alpine.js via HTML attributes.
 
-    Usage:
-        {{ my_list|json_dumps }}
-    """
+@register.filter
+def json_dumps_uri(value):
+    """JSON + URL-encode, for values passed as a quoted string and read back with
+    decodeURIComponent (combobox). Use json_dumps for bare x-data literals."""
     return quote(json.dumps(value))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "django-cotton-ui"
-version = "0.2.1"
+version = "0.2.2"
 description = "UI component library for Django Cotton"
 authors = ["Will Abbott <willabb83@gmail.com>"]
 license = "MIT"

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cotton-ui",
-    "version": "0.1.0",
+    "version": "0.2.2",
     "description": "Cotton UI component library",
     "main": "dist/cotton-ui/cotton-ui.js",
     "author": "wrabit",


### PR DESCRIPTION
0.2.0 and 0.2.1 had an issue with interactive components: calendar, datepicker, radio/checkbox groups and accordion 

- json_dumps now emits plain JSON.
- combobox passes a quoted string through decodeURIComponent, so it keeps the URL-encoded form via a new json_dumps_uri filter.