### PR TITLE
form controls use the control radius

### DIFF
--- a/django_cotton_ui/templates/cotton/ui/composer.html
+++ b/django_cotton_ui/templates/cotton/ui/composer.html
@@ -27,7 +27,7 @@ Fill the `leading` and `trailing` slots with actions (a model picker, mic, send,
         }
     }"
     x-init="$nextTick(() => grow())"
-    class="rounded-box border border-ink-300 dark:border-ink-700 {{ variant_classes|get_item:variant }} shadow-[var(--shadow-input)]
+    class="rounded-control border border-ink-300 dark:border-ink-700 {{ variant_classes|get_item:variant }} shadow-[var(--shadow-input)]
            focus-within:border-accent focus-within:ring-[length:var(--focus-ring-width)] focus-within:ring-[var(--focus-ring-color)]
            transition-colors {% if disabled %}opacity-50{% endif %}"
 >

--- a/django_cotton_ui/templates/cotton/ui/menu/trigger.html
+++ b/django_cotton_ui/templates/cotton/ui/menu/trigger.html
@@ -19,7 +19,7 @@
     @blur="focused = false"
     :disabled="disabled"
     {{ attrs }}
-    class="flex items-center text-left justify-between w-full rounded-box border transition-colors
+    class="flex items-center text-left justify-between w-full rounded-control border transition-colors
            {{ size_classes|get_item:size }}
            bg-[var(--color-input-bg)]
            border-ink-300 dark:border-ink-700

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "django-cotton-ui"
-version = "0.2.15"
+version = "0.2.16"
 description = "UI component library for Django Cotton"
 authors = ["Will Abbott <willabb83@gmail.com>"]
 license = "MIT"

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cotton-ui",
-    "version": "0.2.15",
+    "version": "0.2.16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cotton-ui",
-            "version": "0.2.15",
+            "version": "0.2.16",
             "license": "MIT",
             "dependencies": {
                 "date-fns": "^3.6.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cotton-ui",
-    "version": "0.2.15",
+    "version": "0.2.16",
     "description": "Cotton UI component library",
     "main": "dist/cotton-ui/cotton-ui.js",
     "author": "wrabit",


### PR DESCRIPTION
The select listbox trigger and the composer are form inputs but were on the structural box radius. Switch them to rounded-control so they track --radius-control like the other inputs (the dropdown panel stays on the box radius, as a menu surface).